### PR TITLE
Backend for ckanext-fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 # ckanext-fork
 
-**TODO:** Put a description of your extension here:  What does it do? What features does it have? Consider including some screenshots or embedding a video!
+This extension offers tools to "fork" datasets and resources in CKAN.  To "fork" a dataset or resources is to duplicate/copy/clone the object from one part of the system to another, whilst making sure we record the action appropriatley in the metadata. 
+
+The extension can only be used with CKAN instances using ckanext-blob-storage and Giftless as a file store. This is because duplicating data files is a costly and resource-intensive task in a traditional CKAN instance, but ckanext-blob-storage reduces this task to just duplicating metadata. 
+
+For the purposes of forking a resource, this extension introduces three optional new metadata fields for resources: 
+ - `fork_resource` records the resource_id of the forked_resource;
+ - `fork_activity` records the activity ID of the forked resource's dataset at the time of forking;
+ - `fork_synced` is a pseudo field generated when viewing a dataset that informs you whether the current data matches the forked data.
+
+If `fork_resource` exists in a `package_update/create` request, or a `resource_update/create` request, then the blob_storage metadata will always be overwritten with the metadata of the specified forked_resource. To stop forking a resource, you must set this field to be Falsy. 
 
 
 ## Requirements

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -33,6 +33,19 @@ def dataset_fork(context, data_dict):
     return toolkit.get_action('package_show')(context, {'id': new_dataset['id']})
 
 
+def resource_fork(context, data_dict):
+    resource_id = toolkit.get_or_bust(data_dict, 'id')
+    activity_id = data_dict.pop('activity_id', None)
+    forked_data = util.get_forked_data(context, resource_id, activity_id)
+    resource = forked_data['resource']
+    resource.pop('id')
+    data_dict.pop('id')
+    data_dict['fork_resource'] = resource_id
+    data_dict['fork_activity'] = forked_data['activity_id']
+    resource = {**resource, **data_dict}
+    new_resource = toolkit.get_action('resource_create')(context, resource)
+    return toolkit.get_action('resource_show')({'for_View': True}, {'id': new_resource['id']})
+
 
 @logic.validate(logic.schema.default_autocomplete_schema)
 def resource_autocomplete(context, data_dict):
@@ -86,10 +99,12 @@ def package_create_update(next_action, context, data_dict):
 def package_show(next_action, context, data_dict):
     dataset = next_action(context, data_dict)
 
-    for resource in dataset.get("resources", []):
+    if context.get('check_synced', True):
 
-        if resource.get("fork_resource"):
-            resource['fork_synced'] = util.is_synced_fork(context, resource)
+        for resource in dataset.get("resources", []):
+
+            if resource.get("fork_resource"):
+                resource['fork_synced'] = util.is_synced_fork(context, resource)
 
     return dataset
 

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -43,31 +43,23 @@ def resource_autocomplete(context, data_dict):
 
 @toolkit.chained_action
 def package_create_update(next_action, context, data_dict):
+
     for resource in data_dict.get("resources", []):
+
         if resource.get("fork_resource"):
             resource = util.blob_storage_fork_resource(context, resource)
+
     return next_action(context, data_dict)
 
 
 @toolkit.chained_action
 def package_show(next_action, context, data_dict):
     dataset = next_action(context, data_dict)
-    for resource in dataset["resources"]:
+
+    for resource in dataset.get("resources", []):
+
         if resource.get("fork_resource"):
-            forked_resource_id = resource.get("fork_resource")
-            forked_activity_id = resource.get("fork_activity")
-            forked_data = util.get_forked_data(
-                context,
-                forked_resource_id,
-                forked_activity_id
-            )
-            resource["fork_metadata"] = {
-                "resource_id": forked_resource_id,
-                "resource_name": forked_data["resource"]["name"],
-                "dataset_id": forked_data["dataset"]["id"],
-                "dataset_title": forked_data["dataset"]["title"],
-                "activity_id": forked_data["activity_id"],
-                "synced": util.is_synced_fork(context, resource)
-            }
+            resource['fork_synced'] = util.is_synced_fork(context, resource)
+
     return dataset
 

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -44,8 +44,8 @@ def resource_autocomplete(context, data_dict):
 @toolkit.chained_action
 def package_create_update(next_action, context, data_dict):
     for resource in data_dict.get("resources", []):
-        if resource.get("fork"):
-            resource = util.blob_storage_duplicate_resource(context, resource)
+        if resource.get("fork_resource"):
+            resource = util.blob_storage_fork_resource(context, resource)
     return next_action(context, data_dict)
 
 
@@ -53,14 +53,15 @@ def package_create_update(next_action, context, data_dict):
 def package_show(next_action, context, data_dict):
     dataset = next_action(context, data_dict)
     for resource in dataset["resources"]:
-        if resource.get("fork"):
-            forked_resource_id, forked_activity_id = util.parse_fork(resource["fork"])
+        if resource.get("fork_resource"):
+            forked_resource_id = resource.get("fork_resource")
+            forked_activity_id = resource.get("fork_activity")
             forked_data = util.get_forked_data(
                 context,
                 forked_resource_id,
                 forked_activity_id
             )
-            resource["forked_resource"] = {
+            resource["fork_metadata"] = {
                 "resource_id": forked_resource_id,
                 "resource_name": forked_data["resource"]["name"],
                 "dataset_id": forked_data["dataset"]["id"],
@@ -69,3 +70,4 @@ def package_show(next_action, context, data_dict):
                 "synced": util.is_synced_fork(context, resource)
             }
     return dataset
+

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -1,0 +1,40 @@
+import ckan.logic as logic
+import ckan.plugins.toolkit as toolkit
+
+
+@logic.validate(logic.schema.default_autocomplete_schema)
+def resource_autocomplete(context, data_dict):
+    q = toolkit.get_or_bust(data_dict, 'q')
+    q_lower = q.lower()
+    results = toolkit.get_action('package_search')(context, {
+        "q": q,
+        "rows": 10
+    })['results']
+    pkg_list = []
+
+    for package in results:
+        resources = []
+
+        for resource in package['resources']:
+            last_modified = toolkit.h.time_ago_from_timestamp(resource['last_modified'])
+            match = q_lower in resource['name'].lower()
+            resources.append({
+                'id': resource['id'],
+                'name': resource['name'],
+                'last_modified': last_modified,
+                'match': match
+            })
+
+        organization = package.get('organization')
+        organization_title = organization['title'] if organization else ""
+        match = q_lower in package['name'].lower() or q_lower in package['title'].lower()
+        pkg_list.append({
+            'id': package['id'],
+            'name': package['name'],
+            'title': package['title'],
+            'owner_org': organization_title,
+            'match': match,
+            'resources': resources
+        })
+
+    return pkg_list

--- a/ckanext/fork/helpers.py
+++ b/ckanext/fork/helpers.py
@@ -1,0 +1,30 @@
+from ckanext.fork.util import get_forked_data
+from ckan.plugins import toolkit
+
+
+def fork_metadata(resource):
+    metadata = {}
+
+    if resource.get('fork_resource'):
+        forked_resource_id = resource.get("fork_resource")
+        forked_activity_id = resource.get("fork_activity")
+
+        try:
+            forked_data = get_forked_data(
+                {},
+                forked_resource_id,
+                forked_activity_id
+            )
+            metadata = {
+                "resource_id": forked_resource_id,
+                "resource_name": forked_data["resource"]["name"],
+                "dataset_id": forked_data["dataset"]["id"],
+                "dataset_name": forked_data["dataset"]["name"],
+                "dataset_title": forked_data["dataset"]["title"],
+                "activity_id": forked_data["activity_id"]
+            }
+        except toolkit.NotAuthorized:
+            pass
+
+    return metadata
+

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -18,32 +18,55 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     # IDatasetForm
     def create_package_schema(self):
-        schema = super(ForkPlugin, self).create_package_schema()
-        schema['resources'].update({
-            'fork_resource': [
+        schema = super(ForkPlugin, self).update_package_schema()
+        schema.update({
+            'fork_dataset': [
                 toolkit.get_validator('ignore_missing'),
-                toolkit.get_validator('valid_fork_resource'),
+                toolkit.get_validator('valid_dataset_id')
             ],
             'fork_activity': [
                 toolkit.get_validator('ignore_missing'),
-                toolkit.get_validator('valid_fork_activity'),
+                toolkit.get_validator('valid_activity_id'),
+                toolkit.get_validator('check_forked_object')
             ]
         })
-        return schema
+        schema['resources'].update({
+            'fork_resource': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_resource_id'),
+            ],
+            'fork_activity': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_activity_id'),
+                toolkit.get_validator('check_forked_object')
+            ]
+        })
+        return schema()
 
     def update_package_schema(self):
         schema = super(ForkPlugin, self).update_package_schema()
-        schema['resources'].update({
-            'fork_resource': [
+        schema.update({
+            'fork_dataset': [
                 toolkit.get_validator('ignore_missing'),
-                toolkit.get_validator('valid_fork_resource'),
+                toolkit.get_validator('dataset_field_not_changed')
             ],
             'fork_activity': [
                 toolkit.get_validator('ignore_missing'),
-                toolkit.get_validator('valid_fork_activity'),
+                toolkit.get_validator('dataset_field_not_changed')
             ]
         })
-        return schema
+        schema['resources'].update({
+            'fork_resource': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_resource_id'),
+            ],
+            'fork_activity': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_activity_id'),
+                toolkit.get_validator('check_forked_object')
+            ]
+        })
+        return schema()
 
     def is_fallback(self):
         # Return True to register this plugin as the default handler for
@@ -61,12 +84,16 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'resource_autocomplete': fork_actions.resource_autocomplete,
             'package_show': fork_actions.package_show,
             'package_create': fork_actions.package_create_update,
-            'package_update': fork_actions.package_create_update
+            'package_update': fork_actions.package_create_update,
+            'dataset_fork': fork_actions.dataset_fork
         }
 
     # IValidators
     def get_validators(self):
         return {
-            'valid_fork_resource': fork_validators.valid_fork_resource,
-            'valid_fork_activity': fork_validators.valid_fork_activity
+            'valid_resource_id': fork_validators.valid_resource_id,
+            'valid_dataset_id': fork_validators.valid_dataset_id,
+            'valid_activity_id': fork_validators.valid_activity_id,
+            'check_forked_object': fork_validators.check_forked_object,
+            'dataset_field_not_changed': fork_validators.dataset_field_not_changed
         }

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -1,12 +1,20 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import ckanext.fork.actions as fork_actions
 
 
 class ForkPlugin(plugins.SingletonPlugin):
 
     plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.IActions)
 
     # IConfigurer
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
+
+    # IActions
+    def get_actions(self):
+        return {
+            'resource_autocomplete': fork_actions.resource_autocomplete
+        }

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -85,7 +85,8 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'package_show': fork_actions.package_show,
             'package_create': fork_actions.package_create_update,
             'package_update': fork_actions.package_create_update,
-            'dataset_fork': fork_actions.dataset_fork
+            'dataset_fork': fork_actions.dataset_fork,
+            'resource_fork': fork_actions.resource_fork
         }
 
     # IValidators

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -1,20 +1,60 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckanext.fork.actions as fork_actions
+import ckanext.fork.validators as fork_validators
 
 
-class ForkPlugin(plugins.SingletonPlugin):
+class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IDatasetForm)
+    plugins.implements(plugins.IValidators)
 
     # IConfigurer
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
 
+    # IDatasetForm
+    def create_package_schema(self):
+        schema = super(ForkPlugin, self).create_package_schema()
+        schema['resources'].update({
+            'fork': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_fork'),
+            ]
+        })
+        return schema
+
+    def update_package_schema(self):
+        schema = super(ForkPlugin, self).update_package_schema()
+        schema['resources'].update({
+            'fork': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_fork')
+            ]
+        })
+        return schema
+
+    def is_fallback(self):
+        # Return True to register this plugin as the default handler for
+        # package types not handled by any other IDatasetForm plugin.
+        return False
+
+    def package_types(self):
+        # This plugin doesn't handle any special package types, it just
+        # registers itself as the default (above).
+        return []
+
     # IActions
     def get_actions(self):
         return {
             'resource_autocomplete': fork_actions.resource_autocomplete
+        }
+
+    # IValidators
+    def get_validators(self):
+        return {
+            'valid_fork': fork_validators.valid_fork
         }

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -3,12 +3,10 @@ import ckan.plugins.toolkit as toolkit
 
 
 class ForkPlugin(plugins.SingletonPlugin):
+
     plugins.implements(plugins.IConfigurer)
 
     # IConfigurer
-
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
-        toolkit.add_resource('fanstatic',
-            'fork')

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -20,9 +20,13 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def create_package_schema(self):
         schema = super(ForkPlugin, self).create_package_schema()
         schema['resources'].update({
-            'fork': [
+            'fork_resource': [
                 toolkit.get_validator('ignore_missing'),
-                toolkit.get_validator('valid_fork'),
+                toolkit.get_validator('valid_fork_resource'),
+            ],
+            'fork_activity': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_fork_activity'),
             ]
         })
         return schema
@@ -30,9 +34,13 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def update_package_schema(self):
         schema = super(ForkPlugin, self).update_package_schema()
         schema['resources'].update({
-            'fork': [
+            'fork_resource': [
                 toolkit.get_validator('ignore_missing'),
-                toolkit.get_validator('valid_fork')
+                toolkit.get_validator('valid_fork_resource'),
+            ],
+            'fork_activity': [
+                toolkit.get_validator('ignore_missing'),
+                toolkit.get_validator('valid_fork_activity'),
             ]
         })
         return schema
@@ -59,5 +67,6 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     # IValidators
     def get_validators(self):
         return {
-            'valid_fork': fork_validators.valid_fork
+            'valid_fork_resource': fork_validators.valid_fork_resource,
+            'valid_fork_activity': fork_validators.valid_fork_activity
         }

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -50,7 +50,10 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     # IActions
     def get_actions(self):
         return {
-            'resource_autocomplete': fork_actions.resource_autocomplete
+            'resource_autocomplete': fork_actions.resource_autocomplete,
+            'package_show': fork_actions.package_show,
+            'package_create': fork_actions.package_create_update,
+            'package_update': fork_actions.package_create_update
         }
 
     # IValidators

--- a/ckanext/fork/tests/conftest.py
+++ b/ckanext/fork/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from ckan.tests import factories
+from ckan.tests.helpers import call_action
+
+
+@pytest.fixture
+def forked_data():
+    giftless_metadata = {
+        "sha256": "dummysha",
+        "size": 999,
+        "lfs_prefix": "test/resource",
+        "url_type": "upload"
+    }
+    forked_dataset = factories.Dataset()
+    forked_resource = factories.Resource(
+        package_id=forked_dataset['id'],
+        **giftless_metadata
+    )
+    call_action('package_patch', id=forked_dataset['id'], notes='An activity')
+    forked_activity_id = call_action(
+        'package_activity_list',
+        id=forked_dataset['id']
+    )[0]['id']
+    return {
+        'dataset': forked_dataset,
+        'resource': forked_resource,
+        'activity_id': forked_activity_id
+    }

--- a/ckanext/fork/tests/test_actions.py
+++ b/ckanext/fork/tests/test_actions.py
@@ -37,22 +37,6 @@ def datasets(reset_db, reset_index):
     return datasets
 
 
-@pytest.fixture
-def dataset():
-    org = factories.Organization()
-    dataset = factories.Dataset(
-        type='auto-generate-name-from-title',
-        id="test-id",
-        owner_org=org['id']
-    )
-    resources = []
-    for i in range(3):
-        resources.append(factories.Resource(package_id=dataset['id']))
-    call_action('package_update', id=dataset['id'], notes="Create an activity")
-    return call_action('package_show', id=dataset['id'])
-
-
-
 @pytest.mark.usefixtures('with_request_context')
 class TestResourceAutocomplete():
 
@@ -199,6 +183,25 @@ class TestPackageUpdate():
             assert resource[key] == forked_data['resource'][key]
 
 
+@pytest.fixture
+def dataset():
+    org = factories.Organization()
+    dataset = factories.Dataset(
+        type='auto-generate-name-from-title',
+        id="test-id",
+        owner_org=org['id'],
+    )
+    dataset['resources'] = resources=[factories.Resource(
+        package_id='test-id',
+        sha256='testsha256',
+        size=999,
+        lfs_prefix='test/prefix',
+        url_type='upload'
+    ) for i in range(3)]
+    call_action('package_patch', id=dataset['id'], notes="Create an activity")
+    return call_action('package_show', id=dataset['id'])
+
+
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestDatasetFork():
 
@@ -209,8 +212,8 @@ class TestDatasetFork():
             name="duplicated-dataset"
         )
         fields = ['title', 'notes', 'private', 'num_resources']
-        duplicated = [result[field] == dataset[field] for field in fields]
-        assert all(duplicated), f"Duplication failed: {zip(fields, duplicated)}"
+        duplicated = [result.get(field) == dataset.get(field) for field in fields]
+        assert all(duplicated), f"Duplication failed: {list(zip(fields, duplicated))}"
 
     def test_dataset_metadata_not_duplicated(self, dataset):
         result = call_action(
@@ -219,8 +222,8 @@ class TestDatasetFork():
             name="duplicated-dataset"
         )
         fields = ['name', 'id']
-        not_duplicated = [result[field] != dataset[field] for field in fields]
-        assert all(not_duplicated), f"Duplication occured: {zip(fields, not_duplicated)}"
+        not_duplicated = [result.get(field) != dataset.get(field) for field in fields]
+        assert all(not_duplicated), f"Duplication occured: {list(zip(fields, not_duplicated))}"
 
     def test_resource_metadata_duplicated(self, dataset):
         result = call_action(
@@ -229,7 +232,7 @@ class TestDatasetFork():
             name="duplicated-dataset"
         )
         assert len(dataset['resources']) == len(result['resources'])
-        fields = ['name']
+        fields = ['name', 'sha256', 'size', 'lfs_prefix', 'url_type']
 
         for i in range(len(dataset['resources'])):
             for f in fields:
@@ -259,3 +262,44 @@ class TestDatasetFork():
         result = call_action('dataset_fork', **data_dict)
         assert result[key] == value
 
+
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
+class TestResourceFork():
+
+    def test_resource_metadata_duplicated(self, dataset):
+        resource = dataset['resources'][0]
+        result = call_action(
+            'resource_fork',
+            id=resource['id']
+        )
+        fields = ['name', 'sha256', 'size', 'lfs_prefix', 'url_type']
+        duplicated = [result.get(field) == resource.get(field) for field in fields]
+        assert all(duplicated), f"Duplication failed: {list(zip(fields, duplicated))}"
+
+    def test_resource_metadata_not_duplicated(self, dataset):
+        result = call_action(
+            'resource_fork',
+            id=dataset['resources'][0]['id']
+        )
+        assert dataset['resources'][0]['id'] != result['id']
+
+    def test_resource_not_found(self):
+        with pytest.raises(toolkit.ObjectNotFound):
+            call_action(
+                'resource_fork',
+                id='non-existant-id'
+            )
+
+    @pytest.mark.parametrize('key, value', [
+        ('name', 'A new name'),
+        ('name', ''),
+        ('format', 'NEW'),
+        ('format', 'JSON')
+    ])
+    def test_metadata_overidden(self, key, value, dataset):
+        data_dict = {
+            'id': dataset['resources'][0]['id'],
+            key: value
+        }
+        result = call_action('resource_fork', **data_dict)
+        assert result[key] == value

--- a/ckanext/fork/tests/test_actions.py
+++ b/ckanext/fork/tests/test_actions.py
@@ -1,6 +1,7 @@
 import pytest
 import ckan.plugins.toolkit as toolkit
-from ckan.tests import factories, helpers
+from ckan.tests import factories
+from ckan.tests.helpers import call_action
 
 
 @pytest.fixture(scope="class")
@@ -39,7 +40,7 @@ class TestResourceAutocomplete():
 
     def test_resource_autocomplete_raises_error_if_no_query(self):
         with pytest.raises(toolkit.ValidationError):
-            helpers.call_action('resource_autocomplete')
+            call_action('resource_autocomplete')
 
     @pytest.mark.parametrize("q,result_names", [
         ('02', ['test-dataset-02', 'test-dataset-00']),
@@ -48,11 +49,11 @@ class TestResourceAutocomplete():
         ('Resource 01', ['test-dataset-01', 'test-dataset-00']),
     ])
     def test_resource_autocomplete(self, q, result_names, datasets):
-        result = helpers.call_action('resource_autocomplete', q=q)
+        result = call_action('resource_autocomplete', q=q)
         assert result_names == [d['name'] for d in result]
 
     def test_resource_autocomplete_output_format(self, datasets):
-        result = helpers.call_action('resource_autocomplete', q="Test Resource 08")
+        result = call_action('resource_autocomplete', q="Test Resource 08")
         assert type(result) == list
         for dataset in result:
             assert set(dataset.keys()) == {
@@ -70,3 +71,139 @@ class TestResourceAutocomplete():
                     'match',
                     'last_modified'
                 }
+
+
+@pytest.fixture
+def forked_data():
+    giftless_metadata = {
+        "sha256": "dummysha",
+        "size": 999,
+        "lfs_prefix": "test/resource",
+        "url_type": "upload"
+    }
+    forked_dataset = factories.Dataset()
+    forked_resource = factories.Resource(
+        package_id=forked_dataset['id'],
+        **giftless_metadata
+    )
+    call_action('package_patch', id=forked_dataset['id'], notes='An activity')
+    forked_activity_id = call_action(
+        'package_activity_list',
+        id=forked_dataset['id']
+    )[0]['id']
+    return {
+        'dataset': forked_dataset,
+        'resource': forked_resource,
+        'activity_id': forked_activity_id
+    }
+
+
+@pytest.mark.usefixtures('clean_db')
+class TestPackageShow():
+
+    def test_synced_fork_display(self, forked_data):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork=forked_data['resource']['id']
+        )
+        response = call_action('resource_show', id=resource['id'])
+        assert response['forked_resource'] == {
+            'resource_id': forked_data['resource']['id'],
+            'resource_name': forked_data['resource']['name'],
+            'dataset_id': forked_data['dataset']['id'],
+            'dataset_title': forked_data['dataset']['title'],
+            'activity_id': forked_data['activity_id'],
+            'synced': True
+        }
+
+    def test_unsynced_fork(self, forked_data):
+        call_action('resource_patch', id=forked_data['resource']['id'], sha256='newsha')
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        )
+        response = call_action('resource_show', id=resource['id'])
+        assert not response['forked_resource']['synced']
+
+
+@pytest.mark.usefixtures('clean_db')
+class TestPackageCreate():
+
+    def test_resource_create_with_no_activity_id(self, forked_data):
+        dataset = factories.Dataset()
+        resource = call_action(
+            "resource_create",
+            package_id=dataset['id'],
+            fork=forked_data['resource']['id']
+        )
+        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        assert resource['fork'] == expected_fork
+        for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
+            assert resource[key] == forked_data['resource'][key]
+
+    def test_resource_create_with_activity_id(self, forked_data):
+        call_action('resource_patch', id=forked_data['resource']['id'], sha256='newsha')
+        dataset = factories.Dataset()
+        resource = call_action(
+            "resource_create",
+            package_id=dataset['id'],
+            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        )
+        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        assert resource['fork'] == expected_fork
+        for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
+            assert resource[key] == forked_data['resource'][key]
+
+
+@pytest.mark.usefixtures('clean_db')
+class TestPackageUpdate():
+
+    def test_resource_update_with_no_activity_id(self, forked_data):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork=forked_data['resource']['id']
+        )
+        forked_data['resource'] = call_action(
+            'resource_patch',
+            id=forked_data['resource']['id'],
+            sha256='newsha'
+        )
+        forked_data['activity_id'] = call_action(
+            'package_activity_list',
+            id=forked_data['dataset']['id']
+        )[0]['id']
+        resource = call_action(
+            "resource_update",
+            id=resource['id'],
+            fork=forked_data['resource']['id']
+        )
+        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        assert resource['fork'] == expected_fork
+        for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
+            assert resource[key] == forked_data['resource'][key]
+
+    def test_resource_update_with_activity_id(self, forked_data):
+        call_action('resource_patch', id=forked_data['resource']['id'], sha256='newsha')
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork=forked_data['resource']['id']
+        )
+        resource = call_action(
+            "resource_update",
+            id=resource['id'],
+            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        )
+        resource = factories.Resource(package_id=dataset['id'])
+        resource = call_action(
+            "resource_update",
+            id=resource['id'],
+            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        )
+        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+        assert resource['fork'] == expected_fork
+        for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
+            assert resource[key] == forked_data['resource'][key]

--- a/ckanext/fork/tests/test_actions.py
+++ b/ckanext/fork/tests/test_actions.py
@@ -1,0 +1,72 @@
+import pytest
+import ckan.plugins.toolkit as toolkit
+from ckan.tests import factories, helpers
+
+
+@pytest.fixture(scope="class")
+def datasets(reset_db, reset_index):
+    """
+    Creates 3 datasets each with three resources. Both
+    datasets and resources are numbered uniquely and
+    incrementally.
+
+    Test Dataset 01 contains:
+        Test Resource 00, Test Resource 01, Test Resource 02
+    Test Dataset 02 contains:
+        Test Resource 03, Test Resource 04, Test Resource 05
+    Test Dataset 03 contains:
+        Test Resource 06, Test Resource 07, Test Resource 08
+
+    """
+    reset_db()
+    reset_index()
+    organization = factories.Organization()
+    datasets = [factories.Dataset(
+        title=f"Test Dataset {i:02d}",
+        name=f"test-dataset-{i:02d}",
+        owner_org=organization['id']
+    ) for i in range(3)]
+    for (d, dataset) in enumerate(datasets):
+        dataset["resources"] = [factories.Resource(
+            name=f"Test Resource {(d*3)+r:02d}",
+            package_id=dataset['id']
+        ) for r in range(3)]
+    return datasets
+
+
+@pytest.mark.usefixtures('with_request_context')
+class TestResourceAutocomplete():
+
+    def test_resource_autocomplete_raises_error_if_no_query(self):
+        with pytest.raises(toolkit.ValidationError):
+            helpers.call_action('resource_autocomplete')
+
+    @pytest.mark.parametrize("q,result_names", [
+        ('02', ['test-dataset-02', 'test-dataset-00']),
+        ('00', ['test-dataset-00', 'test-dataset-02', 'test-dataset-01']),
+        ('01', ['test-dataset-01', 'test-dataset-00']),
+        ('Resource 01', ['test-dataset-01', 'test-dataset-00']),
+    ])
+    def test_resource_autocomplete(self, q, result_names, datasets):
+        result = helpers.call_action('resource_autocomplete', q=q)
+        assert result_names == [d['name'] for d in result]
+
+    def test_resource_autocomplete_output_format(self, datasets):
+        result = helpers.call_action('resource_autocomplete', q="Test Resource 08")
+        assert type(result) == list
+        for dataset in result:
+            assert set(dataset.keys()) == {
+                'id',
+                'name',
+                'title',
+                'owner_org',
+                'match',
+                'resources'
+            }
+            for resource in dataset['resources']:
+                assert set(resource.keys()) == {
+                    'id',
+                    'name',
+                    'match',
+                    'last_modified'
+                }

--- a/ckanext/fork/tests/test_actions.py
+++ b/ckanext/fork/tests/test_actions.py
@@ -105,10 +105,10 @@ class TestPackageShow():
         dataset = factories.Dataset()
         resource = factories.Resource(
             package_id=dataset['id'],
-            fork=forked_data['resource']['id']
+            fork_resource=forked_data['resource']['id']
         )
         response = call_action('resource_show', id=resource['id'])
-        assert response['forked_resource'] == {
+        assert response['fork_metadata'] == {
             'resource_id': forked_data['resource']['id'],
             'resource_name': forked_data['resource']['name'],
             'dataset_id': forked_data['dataset']['id'],
@@ -122,10 +122,11 @@ class TestPackageShow():
         dataset = factories.Dataset()
         resource = factories.Resource(
             package_id=dataset['id'],
-            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+            fork_resource=forked_data['resource']['id'],
+            fork_activity=forked_data['activity_id']
         )
         response = call_action('resource_show', id=resource['id'])
-        assert not response['forked_resource']['synced']
+        assert not response['fork_metadata']['synced']
 
 
 @pytest.mark.usefixtures('clean_db')
@@ -136,10 +137,9 @@ class TestPackageCreate():
         resource = call_action(
             "resource_create",
             package_id=dataset['id'],
-            fork=forked_data['resource']['id']
+            fork_resource=forked_data['resource']['id']
         )
-        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
-        assert resource['fork'] == expected_fork
+        assert resource['fork_activity'] == forked_data['activity_id']
         for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
             assert resource[key] == forked_data['resource'][key]
 
@@ -149,10 +149,9 @@ class TestPackageCreate():
         resource = call_action(
             "resource_create",
             package_id=dataset['id'],
-            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+            fork_resource=forked_data['resource']['id'],
+            fork_activity=forked_data['activity_id']
         )
-        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
-        assert resource['fork'] == expected_fork
         for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
             assert resource[key] == forked_data['resource'][key]
 
@@ -164,7 +163,7 @@ class TestPackageUpdate():
         dataset = factories.Dataset()
         resource = factories.Resource(
             package_id=dataset['id'],
-            fork=forked_data['resource']['id']
+            fork_resource=forked_data['resource']['id']
         )
         forked_data['resource'] = call_action(
             'resource_patch',
@@ -178,10 +177,9 @@ class TestPackageUpdate():
         resource = call_action(
             "resource_update",
             id=resource['id'],
-            fork=forked_data['resource']['id']
+            fork_resource=forked_data['resource']['id']
         )
-        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
-        assert resource['fork'] == expected_fork
+        assert resource['fork_activity'] == forked_data['activity_id']
         for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
             assert resource[key] == forked_data['resource'][key]
 
@@ -190,20 +188,20 @@ class TestPackageUpdate():
         dataset = factories.Dataset()
         resource = factories.Resource(
             package_id=dataset['id'],
-            fork=forked_data['resource']['id']
+            fork_resource=forked_data['resource']['id']
         )
         resource = call_action(
             "resource_update",
             id=resource['id'],
-            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+            fork_resource=forked_data['resource']['id'],
+            fork_activity=forked_data['activity_id']
         )
         resource = factories.Resource(package_id=dataset['id'])
         resource = call_action(
             "resource_update",
             id=resource['id'],
-            fork=f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
+            fork_resource=forked_data['resource']['id'],
+            fork_activity=forked_data['activity_id']
         )
-        expected_fork = f"{forked_data['resource']['id']}@{forked_data['activity_id']}"
-        assert resource['fork'] == expected_fork
         for key in ['sha256', 'size', 'lfs_prefix', 'url_type']:
             assert resource[key] == forked_data['resource'][key]

--- a/ckanext/fork/tests/test_helpers.py
+++ b/ckanext/fork/tests/test_helpers.py
@@ -1,0 +1,45 @@
+import pytest
+from ckan.tests import factories
+from ckanext.fork import helpers
+from ckan.plugins import toolkit
+import mock
+
+
+@pytest.mark.usefixtures('clean_db', 'with_request_context')
+class TestForkMetadata():
+
+    def test_expected_behaviour(self, forked_data):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork_resource=forked_data['resource']['id']
+        )
+        toolkit.g.user = factories.User(sysadmin=True)['name']
+        response = helpers.fork_metadata(resource)
+        assert response == {
+            'resource_id': forked_data['resource']['id'],
+            'resource_name': forked_data['resource']['name'],
+            'dataset_id': forked_data['dataset']['id'],
+            'dataset_name': forked_data['dataset']['name'],
+            'dataset_title': forked_data['dataset']['title'],
+            'activity_id': forked_data['activity_id']
+        }
+
+    def test_returns_empty_dict_for_no_fork(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id']
+        )
+        response = helpers.fork_metadata(resource)
+        assert response == {}
+
+    @mock.patch('ckanext.fork.helpers.get_forked_data',
+                side_effect=toolkit.NotAuthorized())
+    def test_returns_empty_dict_for_unauthorized_fork(self, mocked_function, forked_data):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork_resource=forked_data['resource']['id']
+        )
+        response = helpers.fork_metadata(resource)
+        assert response == {}

--- a/ckanext/fork/tests/test_plugin.py
+++ b/ckanext/fork/tests/test_plugin.py
@@ -1,53 +1,6 @@
-"""
-Tests for plugin.py.
-
-Tests are written using the pytest library (https://docs.pytest.org), and you
-should read the testing guidelines in the CKAN docs:
-https://docs.ckan.org/en/2.9/contributing/testing.html
-
-To write tests for your extension you should install the pytest-ckan package:
-
-    pip install pytest-ckan
-
-This will allow you to use CKAN specific fixtures on your tests.
-
-For instance, if your test involves database access you can use `clean_db` to
-reset the database:
-
-    import pytest
-
-    from ckan.tests import factories
-
-    @pytest.mark.usefixtures("clean_db")
-    def test_some_action():
-
-        dataset = factories.Dataset()
-
-        # ...
-
-For functional tests that involve requests to the application, you can use the
-`app` fixture:
-
-    from ckan.plugins import toolkit
-
-    def test_some_endpoint(app):
-
-        url = toolkit.url_for('myblueprint.some_endpoint')
-
-        response = app.get(url)
-
-        assert response.status_code == 200
-
-
-To temporary patch the CKAN configuration for the duration of a test you can use:
-
-    import pytest
-
-    @pytest.mark.ckan_config("ckanext.myext.some_key", "some_value")
-    def test_some_action():
-        pass
-"""
 import ckanext.fork.plugin as plugin
 
+
 def test_plugin():
-    pass
+    p = plugin.ForkPlugin()
+    assert p

--- a/ckanext/fork/tests/test_validators.py
+++ b/ckanext/fork/tests/test_validators.py
@@ -8,18 +8,34 @@ from ckan.tests import factories
 @pytest.mark.usefixtures('clean_db')
 class TestValidFork():
 
-    @pytest.mark.parametrize("fork_value, result", [
+    @pytest.mark.parametrize("fork_resource, result", [
         (None, does_not_raise()),
         ("", does_not_raise()),
         ("{resource_id}", does_not_raise()),
-        ("{resource_id}@", does_not_raise()),
-        ("{resource_id}@{activity_id}", does_not_raise()),
-        ("{resource_id}@bad-activity-id", pytest.raises(toolkit.Invalid)),
-        ("bad-resource-id", pytest.raises(toolkit.Invalid)),
-        ("bad-resource-id@bad-activity-id", pytest.raises(toolkit.Invalid)),
-        ("@{activity_id}", pytest.raises(toolkit.Invalid))
+        ("bad-resource-id", pytest.raises(toolkit.Invalid))
     ])
-    def test_valid_fork(self, fork_value, result):
+    def test_valid_fork_resource(self, fork_resource, result):
+        resource = factories.Resource(id="good-resource-id")
+
+        if fork_resource:
+            fork_resource = fork_resource.format(resource_id=resource['id'])
+
+        key = ('resources', 0, 'fork_resource')
+        flattened_data = {key: fork_resource}
+
+        with result:
+            fork_validators.valid_fork_resource(key, flattened_data, {}, {'user': 'user'})
+
+    @pytest.mark.parametrize("fork_resource, fork_activity, result", [
+        (None, None, does_not_raise()),
+        ("", "", does_not_raise()),
+        ("{resource_id}", "{activity_id}", does_not_raise()),
+        ("{resource_id}", "bad-activity-id", pytest.raises(toolkit.Invalid)),
+        ("bad-resource-id", "{activity_id}", does_not_raise()),
+        ("", "{activity_id}", pytest.raises(toolkit.Invalid)),
+        (None, "{activity_id}", pytest.raises(toolkit.Invalid)),
+    ])
+    def test_valid_fork_activity(self, fork_resource, fork_activity, result):
         user = factories.User()
         resource = factories.Resource(id="good-resource-id")
         dataset = factories.Dataset(resources=[resource])
@@ -29,14 +45,17 @@ class TestValidFork():
             user_id=user["id"]
         )
 
-        if fork_value:
-            fork_value = fork_value.format(
-                resource_id=resource['id'],
-                activity_id=activity['id']
-            )
+        if fork_resource:
+            fork_resource = fork_resource.format(resource_id=resource['id'])
 
-        key = ('resources', 0, 'fork')
-        flattened_data = {key: fork_value}
+        if fork_activity:
+            fork_activity = fork_activity.format(activity_id=activity['id'])
+
+        key = ('resources', 0, 'fork_activity')
+        flattened_data = {
+            ('resources', 0, 'fork_resource'): fork_resource,
+            key: fork_activity
+        }
 
         with result:
-            fork_validators.valid_fork(key, flattened_data, {}, {'user': 'user'})
+            fork_validators.valid_fork_activity(key, flattened_data, {}, {'user': 'user'})

--- a/ckanext/fork/tests/test_validators.py
+++ b/ckanext/fork/tests/test_validators.py
@@ -1,0 +1,42 @@
+import pytest
+from contextlib import nullcontext as does_not_raise
+import ckanext.fork.validators as fork_validators
+import ckan.plugins.toolkit as toolkit
+from ckan.tests import factories
+
+
+@pytest.mark.usefixtures('clean_db')
+class TestValidFork():
+
+    @pytest.mark.parametrize("fork_value, result", [
+        (None, does_not_raise()),
+        ("", does_not_raise()),
+        ("{resource_id}", does_not_raise()),
+        ("{resource_id}@", does_not_raise()),
+        ("{resource_id}@{activity_id}", does_not_raise()),
+        ("{resource_id}@bad-activity-id", pytest.raises(toolkit.Invalid)),
+        ("bad-resource-id", pytest.raises(toolkit.Invalid)),
+        ("bad-resource-id@bad-activity-id", pytest.raises(toolkit.Invalid)),
+        ("@{activity_id}", pytest.raises(toolkit.Invalid))
+    ])
+    def test_valid_fork(self, fork_value, result):
+        user = factories.User()
+        resource = factories.Resource(id="good-resource-id")
+        dataset = factories.Dataset(resources=[resource])
+        activity = factories.Activity(
+            activity_type="changed package",
+            object_id=dataset["id"],
+            user_id=user["id"]
+        )
+
+        if fork_value:
+            fork_value = fork_value.format(
+                resource_id=resource['id'],
+                activity_id=activity['id']
+            )
+
+        key = ('resources', 0, 'fork')
+        flattened_data = {key: fork_value}
+
+        with result:
+            fork_validators.valid_fork(key, flattened_data, {}, {'user': 'user'})

--- a/ckanext/fork/util.py
+++ b/ckanext/fork/util.py
@@ -1,26 +1,10 @@
 from ckan.plugins import toolkit
 
 
-def fix_context(context):
-    """
-    The action activity_data_show throws a KeyError if context['user']
-    is not set. There are several places where the action package_show
-    may be called without setting context['user'], in all places I have
-    found this makes sense because 'ignore_auth' is also set to True.
-
-    This work around simply avoids the KeyError that would otherwise be
-    thrown in these situations. In reality I think the activity_data_show
-    action in core CKAN should not require context['user'] if it has no
-    need of the username.
-    """
-    if 'user' not in context and context.get('ignore_auth'):
-        context['user'] = None
-    return context
-
-
 def get_forked_data(context, resource_id, activity_id=None):
+
     if activity_id:
-        dataset = toolkit.get_action('activity_data_show')(fix_context(context), {
+        dataset = toolkit.get_action('activity_data_show')(context, {
             'id': activity_id,
             'object_type': 'package'
         })
@@ -43,8 +27,10 @@ def get_forked_data(context, resource_id, activity_id=None):
 
 
 def is_synced_fork(context, resource):
+
     if not resource.get('fork_resource'):
         return False
+
     forked_resource_id = resource.get('fork_resource')
     forked_resource_current_sha256 = toolkit.get_action("resource_show")(context, {
         'id': forked_resource_id
@@ -56,7 +42,9 @@ def blob_storage_fork_resource(context, resource):
     resource_id = resource.get("fork_resource")
     activity_id = resource.get("fork_activity")
     forked_data = get_forked_data(context, resource_id, activity_id)
+
     for field in ['lfs_prefix', 'size', 'sha256', 'url_type']:
         resource[field] = forked_data['resource'][field]
+
     resource['fork_activity'] = forked_data['activity_id']
     return resource

--- a/ckanext/fork/util.py
+++ b/ckanext/fork/util.py
@@ -1,0 +1,79 @@
+from ckan.plugins import toolkit
+
+
+def parse_fork(value):
+    if not type(value) == str:
+        resource_id = None
+        activity_id = None
+    elif "@" in value:
+        resource_id = value.split("@")[0]
+        activity_id = value.split("@")[-1]
+    else:
+        resource_id = value
+        activity_id = None
+    return resource_id, activity_id
+
+
+def fix_context(context):
+    """
+    The action activity_data_show throws a KeyError if context['user']
+    is not set. There are several places where the action package_show
+    may be called without setting context['user'], in all places I have
+    found this makes sense because 'ignore_auth' is also set to True.
+
+    This work around simply avoids the KeyError that would otherwise be
+    thrown in these situations. In reality I think the activity_data_show
+    action in core CKAN should not require context['user'] if it has no
+    need of the username.
+    """
+    if 'user' not in context and context.get('ignore_auth'):
+        context['user'] = None
+    return context
+
+
+def get_forked_data(context, resource_id, activity_id=None):
+
+    if activity_id:
+        dataset = toolkit.get_action('activity_data_show')(fix_context(context), {
+            'id': activity_id,
+            'object_type': 'package'
+        })
+        resource = [r for r in dataset['resources'] if r['id'] == resource_id][0]
+    else:
+        resource = toolkit.get_action('resource_show')(context, {'id': resource_id})
+        dataset = toolkit.get_action('package_show')(context, {
+            'id': resource['package_id']
+        })
+        activity_id = toolkit.get_action('package_activity_list')(
+            context,
+            {'id': dataset['id']}
+        )[0]['id']
+
+    return {
+        'resource': resource,
+        'dataset': dataset,
+        'activity_id': activity_id
+    }
+
+
+def is_synced_fork(context, resource):
+    if not resource.get('fork'):
+        return False
+    forked_resource_id, _ = parse_fork(resource['fork'])
+    forked_resource_current_sha256 = toolkit.get_action("resource_show")(context, {
+        'id': forked_resource_id
+    }).get("sha256")
+    return forked_resource_current_sha256 == resource.get("sha256")
+
+
+def blob_storage_duplicate_resource(context, resource):
+    fork = resource.get("fork")
+    resource_id, activity_id = parse_fork(fork)
+    forked_data = get_forked_data(context, resource_id, activity_id)
+
+    for field in ['lfs_prefix', 'size', 'sha256', 'url_type']:
+        resource[field] = forked_data['resource'][field]
+
+    resource['fork'] = f"{resource_id}@{forked_data['activity_id']}"
+
+    return resource

--- a/ckanext/fork/util.py
+++ b/ckanext/fork/util.py
@@ -32,9 +32,10 @@ def is_synced_fork(context, resource):
         return False
 
     forked_resource_id = resource.get('fork_resource')
-    forked_resource_current_sha256 = toolkit.get_action("resource_show")(context, {
-        'id': forked_resource_id
-    }).get("sha256")
+    forked_resource_current_sha256 = toolkit.get_action("resource_show")(
+        {**context, 'check_synced': False},
+        {'id': forked_resource_id}
+    ).get("sha256")
     return forked_resource_current_sha256 == resource.get("sha256")
 
 

--- a/ckanext/fork/validators.py
+++ b/ckanext/fork/validators.py
@@ -1,7 +1,7 @@
 import ckan.plugins.toolkit as toolkit
 
 
-def valid_fork_resource(key, data, errors, context):
+def valid_resource_id(key, data, errors, context):
     value = data[key]
 
     if not value:
@@ -13,16 +13,23 @@ def valid_fork_resource(key, data, errors, context):
         raise toolkit.Invalid(toolkit._(f'Resource {value} does not exist'))
 
 
-def valid_fork_activity(key, data, errors, context):
+def valid_dataset_id(key, data, errors, context):
     value = data[key]
 
     if not value:
         return
 
-    resource_key = key[:-1] + ('fork_resource',)
+    try:
+        toolkit.get_action('package_show')(context, {'id': value})
+    except toolkit.ObjectNotFound:
+        raise toolkit.Invalid(toolkit._(f'Dataset {value} does not exist'))
 
-    if not data.get(resource_key):
-        raise toolkit.Invalid(toolkit._("fork_resource not specified"))
+
+def valid_activity_id(key, data, errors, context):
+    value = data[key]
+
+    if not value:
+        return
 
     try:
         toolkit.get_action('activity_show')(context, {
@@ -32,3 +39,32 @@ def valid_fork_activity(key, data, errors, context):
     except toolkit.ObjectNotFound:
         raise toolkit.Invalid(toolkit._(f'Activity {value} does not exist'))
 
+
+def check_forked_object(key, data, errors, context):
+
+    if not data[key]:
+        return
+
+    if len(key) == 1:
+        fork_field = 'fork_dataset'
+        key = (fork_field,)
+    else:
+        fork_field = 'fork_resource'
+        key = key[:-1] + (fork_field,)
+
+    if not data.get(key):
+        raise toolkit.Invalid(toolkit._(f"Object is not forked, please specify {fork_field}"))
+
+
+def dataset_field_not_changed(key, data, errors, context):
+    package = context.get('package')
+
+    if not package:
+        return
+
+    old_value = getattr(package, key[0], '')
+    new_value = data[key]
+
+    if new_value != old_value:
+        raise toolkit.Invalid(f'Cannot change value of key from {old_value} '
+                              f'to {new_value}.  This key is read-only.')

--- a/ckanext/fork/validators.py
+++ b/ckanext/fork/validators.py
@@ -2,7 +2,6 @@ import ckan.plugins.toolkit as toolkit
 
 
 def valid_fork_resource(key, data, errors, context):
-
     value = data[key]
 
     if not value:
@@ -15,7 +14,6 @@ def valid_fork_resource(key, data, errors, context):
 
 
 def valid_fork_activity(key, data, errors, context):
-
     value = data[key]
 
     if not value:

--- a/ckanext/fork/validators.py
+++ b/ckanext/fork/validators.py
@@ -1,0 +1,34 @@
+import ckan.plugins.toolkit as toolkit
+
+
+def valid_fork(key, data, errors, context):
+    """
+    Make sure an field is a valid organization_id
+    """
+
+    value = data[key]
+
+    if not value:
+        return
+
+    if "@" in value:
+        resource_id = value.split("@")[0]
+        activity_id = value.split("@")[-1]
+    else:
+        resource_id = value
+        activity_id = None
+
+    try:
+        toolkit.get_action('resource_show')(context, {'id': resource_id})
+    except toolkit.ObjectNotFound:
+        raise toolkit.Invalid(toolkit._(f'Resource {resource_id} does not exist'))
+
+    if activity_id:
+
+        try:
+            toolkit.get_action('activity_show')(context, {
+                'id': activity_id,
+                'include_data': False
+            })
+        except toolkit.ObjectNotFound:
+            raise toolkit.Invalid(toolkit._(f'Resource {activity_id} does not exist'))

--- a/ckanext/fork/validators.py
+++ b/ckanext/fork/validators.py
@@ -1,4 +1,5 @@
 import ckan.plugins.toolkit as toolkit
+from ckanext.fork.util import parse_fork
 
 
 def valid_fork(key, data, errors, context):
@@ -11,12 +12,7 @@ def valid_fork(key, data, errors, context):
     if not value:
         return
 
-    if "@" in value:
-        resource_id = value.split("@")[0]
-        activity_id = value.split("@")[-1]
-    else:
-        resource_id = value
-        activity_id = None
+    resource_id, activity_id = parse_fork(value)
 
     try:
         toolkit.get_action('resource_show')(context, {'id': resource_id})


### PR DESCRIPTION
This PR covers the first complete implementation of the back end for ckanext-fork. It covers just the backend changes required for the feature, with the front end still to come when Chas is back from holidays. 

Still to do for the extension once this PR is merged.

- [ ] Implement React widget for searching and finding a specific resource.  It will be power by resource_autocomplete action.
- [ ] Implement Jinja2 templates to display fork information
- [ ] Clean up readme/docs
- [x] Add dataset duplication code from Avenir as a feature
