### PR TITLE
SPC-97 Action to fork a resource

### DIFF
--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -99,10 +99,12 @@ def package_create_update(next_action, context, data_dict):
 def package_show(next_action, context, data_dict):
     dataset = next_action(context, data_dict)
 
-    for resource in dataset.get("resources", []):
+    if context.get('check_synced', True):
 
-        if resource.get("fork_resource"):
-            resource['fork_synced'] = util.is_synced_fork(context, resource)
+        for resource in dataset.get("resources", []):
+
+            if resource.get("fork_resource"):
+                resource['fork_synced'] = util.is_synced_fork(context, resource)
 
     return dataset
 

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -86,7 +86,7 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'package_create': fork_actions.package_create_update,
             'package_update': fork_actions.package_create_update,
             'dataset_fork': fork_actions.dataset_fork,
-            'dataset_fork': fork_actions.resource_fork
+            'resource_fork': fork_actions.resource_fork
         }
 
     # IValidators

--- a/ckanext/fork/tests/test_actions.py
+++ b/ckanext/fork/tests/test_actions.py
@@ -37,22 +37,6 @@ def datasets(reset_db, reset_index):
     return datasets
 
 
-@pytest.fixture
-def dataset():
-    org = factories.Organization()
-    dataset = factories.Dataset(
-        type='auto-generate-name-from-title',
-        id="test-id",
-        owner_org=org['id']
-    )
-    resources = []
-    for i in range(3):
-        resources.append(factories.Resource(package_id=dataset['id']))
-    call_action('package_update', id=dataset['id'], notes="Create an activity")
-    return call_action('package_show', id=dataset['id'])
-
-
-
 @pytest.mark.usefixtures('with_request_context')
 class TestResourceAutocomplete():
 
@@ -199,6 +183,25 @@ class TestPackageUpdate():
             assert resource[key] == forked_data['resource'][key]
 
 
+@pytest.fixture
+def dataset():
+    org = factories.Organization()
+    dataset = factories.Dataset(
+        type='auto-generate-name-from-title',
+        id="test-id",
+        owner_org=org['id'],
+    )
+    dataset['resources'] = resources=[factories.Resource(
+        package_id='test-id',
+        sha256='testsha256',
+        size=999,
+        lfs_prefix='test/prefix',
+        url_type='upload'
+    ) for i in range(3)]
+    call_action('package_patch', id=dataset['id'], notes="Create an activity")
+    return call_action('package_show', id=dataset['id'])
+
+
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestDatasetFork():
 
@@ -209,8 +212,8 @@ class TestDatasetFork():
             name="duplicated-dataset"
         )
         fields = ['title', 'notes', 'private', 'num_resources']
-        duplicated = [result[field] == dataset[field] for field in fields]
-        assert all(duplicated), f"Duplication failed: {zip(fields, duplicated)}"
+        duplicated = [result.get(field) == dataset.get(field) for field in fields]
+        assert all(duplicated), f"Duplication failed: {list(zip(fields, duplicated))}"
 
     def test_dataset_metadata_not_duplicated(self, dataset):
         result = call_action(
@@ -219,8 +222,8 @@ class TestDatasetFork():
             name="duplicated-dataset"
         )
         fields = ['name', 'id']
-        not_duplicated = [result[field] != dataset[field] for field in fields]
-        assert all(not_duplicated), f"Duplication occured: {zip(fields, not_duplicated)}"
+        not_duplicated = [result.get(field) != dataset.get(field) for field in fields]
+        assert all(not_duplicated), f"Duplication occured: {list(zip(fields, not_duplicated))}"
 
     def test_resource_metadata_duplicated(self, dataset):
         result = call_action(
@@ -229,7 +232,7 @@ class TestDatasetFork():
             name="duplicated-dataset"
         )
         assert len(dataset['resources']) == len(result['resources'])
-        fields = ['name']
+        fields = ['name', 'sha256', 'size', 'lfs_prefix', 'url_type']
 
         for i in range(len(dataset['resources'])):
             for f in fields:
@@ -259,3 +262,44 @@ class TestDatasetFork():
         result = call_action('dataset_fork', **data_dict)
         assert result[key] == value
 
+
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
+class TestResourceFork():
+
+    def test_resource_metadata_duplicated(self, dataset):
+        resource = dataset['resources'][0]
+        result = call_action(
+            'resource_fork',
+            id=resource['id']
+        )
+        fields = ['name', 'sha256', 'size', 'lfs_prefix', 'url_type']
+        duplicated = [result.get(field) == resource.get(field) for field in fields]
+        assert all(duplicated), f"Duplication failed: {list(zip(fields, duplicated))}"
+
+    def test_resource_metadata_not_duplicated(self, dataset):
+        result = call_action(
+            'resource_fork',
+            id=dataset['resources'][0]['id']
+        )
+        assert dataset['resources'][0]['id'] != result['id']
+
+    def test_resource_not_found(self):
+        with pytest.raises(toolkit.ObjectNotFound):
+            call_action(
+                'resource_fork',
+                id='non-existant-id'
+            )
+
+    @pytest.mark.parametrize('key, value', [
+        ('name', 'A new name'),
+        ('name', ''),
+        ('format', 'NEW'),
+        ('format', 'JSON')
+    ])
+    def test_metadata_overidden(self, key, value, dataset):
+        data_dict = {
+            'id': dataset['resources'][0]['id'],
+            key: value
+        }
+        result = call_action('resource_fork', **data_dict)
+        assert result[key] == value

--- a/ckanext/fork/util.py
+++ b/ckanext/fork/util.py
@@ -32,10 +32,10 @@ def is_synced_fork(context, resource):
         return False
 
     forked_resource_id = resource.get('fork_resource')
-    forked_resource_current_sha256 = toolkit.get_action("resource_show")(context, {
-        'id': forked_resource_id,
-        'check_synced': False
-    }).get("sha256")
+    forked_resource_current_sha256 = toolkit.get_action("resource_show")(
+        {**context, 'check_synced': False},
+        {'id': forked_resource_id}
+    ).get("sha256")
     return forked_resource_current_sha256 == resource.get("sha256")
 
 


### PR DESCRIPTION
This adds a parallel action for dataset_fork called resource_fork.  This means there are two alternative ways to fork a resource, either by updating the metadata, or by calling the resource_fork action.  It is expected that the UI might use the fork metadata fields, but the resource_fork action might be useful for those interacting through the API, or used to forking datasets.  
  