### PR TITLE
ADX-887 fix resource_read access issue

### DIFF
--- a/ckanext/fork/helpers.py
+++ b/ckanext/fork/helpers.py
@@ -2,10 +2,21 @@ from ckanext.fork.util import get_forked_data
 from ckan.plugins import toolkit
 
 def get_parent_resource_details(resource_id):
-    resource = toolkit.get_action('resource_show')(data_dict={'id': resource_id})
-    package = toolkit.get_action('package_show')(data_dict={'id': resource['package_id']})
+    try:
+        resource = toolkit.get_action('resource_show')(data_dict={'id': resource_id})
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': "Unable to access parent resource information; current user may not be authorized to access this."}
+
+    try:
+        package = toolkit.get_action('package_show')(data_dict={'id': resource['package_id']})
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': "Unable to access parent resource package information; current user may not be authorized to access this."}
+
     organization = package['organization']
     return {
+        'success': True,
         'resource': {
             'name': resource['name'],
             'url': resource['url'].split('/download')[0]


### PR DESCRIPTION
So this was actually a problem in a slightly different place than I had thought - the error was being caused not by the edit but by the subsequent read.

Basically, the code I added to create slide 5 of the forking designs calls resource_show and package_show - I thought that these would work for everybody but they are failing due to access rights. I have now caught this, returning a useful error message.

UI changes: fjelltopp/ckanext-unaids#251