### PR TITLE
ADX-919 ckanext-fork needs to maintain original package_update behviour

### DIFF
--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -133,6 +133,9 @@ def package_create_update(next_action, context, data_dict):
         except logic.NotFound as e:
             log.info(f"No existing resource found with error: {e}")
             original_resource_data = {}
+        except KeyError as e:
+            log.info(f"No resource id provided, probably a new resource. Original error: {e}")
+            original_resource_data = {}
         except Exception as e:
             log.exception([
                 "Trying to update a resource but I can't find the original resource ",

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -124,11 +124,30 @@ def _get_dataset_from_resource_uuid(context, uuid):
 
 @toolkit.chained_action
 def package_create_update(next_action, context, data_dict):
-
     for resource in data_dict.get("resources", []):
+        try:
+            original_resource_data = toolkit.get_action('resource_show')(
+                context,
+                {"id": resource["id"]}
+            )
+        except Exception as e:
+            log.info(f"No existing resource found with error: {e}")
+            original_resource_data = {}
 
-        if resource.get("fork_resource"):
-            resource = util.blob_storage_fork_resource(context, resource)
+        if resource.get("fork_resource") or original_resource_data.get("fork_resource"):
+            file_metadata_changed = False
+
+            for key in ['lfs_prefix', 'size', 'sha256', 'url_type']:
+                new_value = resource.get(key, "")
+                if new_value:
+                    original_value = original_resource_data.get(key, "")
+                    file_metadata_changed = file_metadata_changed or original_value != new_value
+
+            if resource.get("fork_resource") and not file_metadata_changed:
+                resource = util.blob_storage_fork_resource(context, resource)
+            else:
+                resource['fork_resource'] = ''
+                resource['fork_activity'] = ''
 
     return next_action(context, data_dict)
 


### PR DESCRIPTION
The new code does the following logic:

1. get the existing data for the resource because we need to know if the resource _was_ a fork; this is a `try` because new resources will fail
2. if either the new data or the existing data mentions forks
  * check for changes in any of 'lfs_prefix', 'size', 'sha256', 'url_type'
  * question: should 'url' be here too? if so it will need parsing because forks get a full URL and files just get a filename it seems? it seems to work without this though?
3. if any of these metadata fields have changed, then reset the resource fork fields in the data_dict before calling the next action, i.e. the previous default behaviour
4. if none of these metadata fields have changed and there is incoming fork information, then call blob_storage_fork_resource

Tested on UI with:
- [x] creating new resource that is fork
- [x] changing fork resource to non-fork
- [x] changing non-fork resource to fork
- [x] updating parent resource
- [x] syncing fork resource after parent change
- [x] changing fields like description and permissions on forked resources

Tested on API with:
- [x] uploading new file to a fork resource, overriding the forkiness

Test suites run