### PR TITLE
ADX-924 ADX-919 regression tests

### DIFF
--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -3,7 +3,7 @@ import ckan.plugins.toolkit as toolkit
 import ckanext.fork.util as util
 import logging
 import re
-from .helpers import check_metadata_for_changes, get_current_resource
+from ckanext.fork.helpers import check_metadata_for_changes, get_current_resource
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -3,7 +3,6 @@ import ckan.plugins.toolkit as toolkit
 import ckanext.fork.util as util
 import logging
 import re
-from ckanext.fork.helpers import check_metadata_for_changes, get_current_resource
 
 log = logging.getLogger(__name__)
 
@@ -135,8 +134,8 @@ def package_create(next_action, context, data_dict):
 @toolkit.chained_action
 def package_update(next_action, context, data_dict):
     for resource in data_dict.get("resources", []):
-        current = get_current_resource(context, resource)
-        resource_metadata_changed = check_metadata_for_changes(current, resource)
+        current = util.get_current_resource(context, resource)
+        resource_metadata_changed = util.check_metadata_for_file_change(current, resource)
         if resource.get("fork_resource") and not resource_metadata_changed:
             resource = util.blob_storage_fork_resource(context, resource)
         else:

--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -3,6 +3,7 @@ import ckan.plugins.toolkit as toolkit
 import ckanext.fork.util as util
 import logging
 import re
+from .helpers import check_metadata_for_changes, get_current_resource
 
 log = logging.getLogger(__name__)
 
@@ -123,41 +124,24 @@ def _get_dataset_from_resource_uuid(context, uuid):
 
 
 @toolkit.chained_action
-def package_create_update(next_action, context, data_dict):
+def package_create(next_action, context, data_dict):
     for resource in data_dict.get("resources", []):
-        try:
-            original_resource_data = toolkit.get_action('resource_show')(
-                context,
-                {"id": resource["id"]}
-            )
-        except logic.NotFound as e:
-            log.info(f"No existing resource found with error: {e}")
-            original_resource_data = {}
-        except KeyError as e:
-            log.info(f"No resource id provided, probably a new resource. Original error: {e}")
-            original_resource_data = {}
-        except Exception as e:
-            log.exception([
-                "Trying to update a resource but I can't find the original resource ",
-                "to check the metadata to catch fork changes."
-            ])
-            raise e
+        if resource.get("fork_resource"):
+            resource = util.blob_storage_fork_resource(context, resource)
 
-        if resource.get("fork_resource") or original_resource_data.get("fork_resource"):
-            file_metadata_changed = False
+    return next_action(context, data_dict)
 
-            for key in ['lfs_prefix', 'size', 'sha256', 'url_type']:
-                new_value = resource.get(key, "")
-                if new_value:
-                    original_value = original_resource_data.get(key, "")
-                    if original_value != new_value:
-                        file_metadata_changed = True
 
-            if resource.get("fork_resource") and not file_metadata_changed:
-                resource = util.blob_storage_fork_resource(context, resource)
-            else:
-                resource['fork_resource'] = ''
-                resource['fork_activity'] = ''
+@toolkit.chained_action
+def package_update(next_action, context, data_dict):
+    for resource in data_dict.get("resources", []):
+        current = get_current_resource(context, resource)
+        resource_metadata_changed = check_metadata_for_changes(current, resource)
+        if resource.get("fork_resource") and not resource_metadata_changed:
+            resource = util.blob_storage_fork_resource(context, resource)
+        else:
+            resource['fork_resource'] = ''
+            resource['fork_activity'] = ''
 
     return next_action(context, data_dict)
 
@@ -174,4 +158,3 @@ def package_show(next_action, context, data_dict):
                 resource['fork_synced'] = util.is_synced_fork(context, resource)
 
     return dataset
-

--- a/ckanext/fork/helpers.py
+++ b/ckanext/fork/helpers.py
@@ -1,5 +1,10 @@
+import logging
+import ckan.logic as logic
 from ckanext.fork.util import get_forked_data
 from ckan.plugins import toolkit
+
+log = logging.getLogger(__name__)
+
 
 def get_parent_resource_details(resource_id):
     try:
@@ -12,7 +17,7 @@ def get_parent_resource_details(resource_id):
         package = toolkit.get_action('package_show')(data_dict={'id': resource['package_id']})
     except toolkit.NotAuthorized:
         return {'success': False,
-                'msg': "Unable to access parent resource package information; current user may not be authorized to access this."}
+                'msg': "Unable to access parent resource information; current user may not be authorized to access this."}
 
     organization = package['organization']
     return {
@@ -31,7 +36,6 @@ def get_parent_resource_details(resource_id):
             'url': '/organization/'+organization['name']
         }
     }
-
 
 
 def fork_metadata(resource):
@@ -60,3 +64,33 @@ def fork_metadata(resource):
 
     return metadata
 
+
+def get_current_resource(context, resource):
+    try:
+        current = toolkit.get_action('resource_show')(
+            context,
+            {"id": resource["id"]}
+        )
+    except logic.NotFound as e:
+        log.info(f"No existing resource found with error: {e}")
+        current = {}
+    except KeyError as e:
+        log.info(f"No resource id provided, probably a new resource. Original error: {e}")
+        current = {}
+    except Exception as e:
+        log.exception(f"I can't find the original resource for unknown reason: {e}")
+        raise e
+
+    return current
+
+
+def check_metadata_for_changes(current, resource):
+    file_metadata_changed = False
+    if resource.get("fork_resource") or current.get("fork_resource"):
+        for key in ['lfs_prefix', 'size', 'sha256', 'url_type']:
+            new_value = resource.get(key, "")
+            if new_value:
+                original_value = current.get(key, "")
+                if original_value != new_value:
+                    file_metadata_changed = True
+    return file_metadata_changed

--- a/ckanext/fork/helpers.py
+++ b/ckanext/fork/helpers.py
@@ -1,9 +1,5 @@
-import logging
-import ckan.logic as logic
 from ckanext.fork.util import get_forked_data
 from ckan.plugins import toolkit
-
-log = logging.getLogger(__name__)
 
 
 def get_parent_resource_details(resource_id):
@@ -63,34 +59,3 @@ def fork_metadata(resource):
             pass
 
     return metadata
-
-
-def get_current_resource(context, resource):
-    try:
-        current = toolkit.get_action('resource_show')(
-            context,
-            {"id": resource["id"]}
-        )
-    except logic.NotFound as e:
-        log.info(f"No existing resource found with error: {e}")
-        current = {}
-    except KeyError as e:
-        log.info(f"No resource id provided, probably a new resource. Original error: {e}")
-        current = {}
-    except Exception as e:
-        log.exception(f"I can't find the original resource for unknown reason: {e}")
-        raise e
-
-    return current
-
-
-def check_metadata_for_changes(current, resource):
-    file_metadata_changed = False
-    if resource.get("fork_resource") or current.get("fork_resource"):
-        for key in ['lfs_prefix', 'size', 'sha256', 'url_type']:
-            new_value = resource.get(key, "")
-            if new_value:
-                original_value = current.get(key, "")
-                if original_value != new_value:
-                    file_metadata_changed = True
-    return file_metadata_changed

--- a/ckanext/fork/helpers.py
+++ b/ckanext/fork/helpers.py
@@ -5,17 +5,13 @@ from ckan.plugins import toolkit
 def get_parent_resource_details(resource_id):
     try:
         resource = toolkit.get_action('resource_show')(data_dict={'id': resource_id})
-    except toolkit.NotAuthorized:
-        return {'success': False,
-                'msg': "Unable to access parent resource information; current user may not be authorized to access this."}
-
-    try:
         package = toolkit.get_action('package_show')(data_dict={'id': resource['package_id']})
     except toolkit.NotAuthorized:
         return {'success': False,
                 'msg': "Unable to access parent resource information; current user may not be authorized to access this."}
 
     organization = package['organization']
+
     return {
         'success': True,
         'resource': {

--- a/ckanext/fork/plugin.py
+++ b/ckanext/fork/plugin.py
@@ -4,6 +4,7 @@ import ckanext.fork.actions as fork_actions
 import ckanext.fork.validators as fork_validators
 from ckanext.fork.helpers import get_parent_resource_details
 
+
 class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     plugins.implements(plugins.IConfigurer)
@@ -84,8 +85,8 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         return {
             'resource_autocomplete': fork_actions.resource_autocomplete,
             'package_show': fork_actions.package_show,
-            'package_create': fork_actions.package_create_update,
-            'package_update': fork_actions.package_create_update,
+            'package_create': fork_actions.package_create,
+            'package_update': fork_actions.package_update,
             'dataset_fork': fork_actions.dataset_fork,
             'resource_fork': fork_actions.resource_fork,
         }
@@ -102,7 +103,4 @@ class ForkPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
 
     # ITemplateHelpers
     def get_helpers(self):
-    # Template helper function names should begin with the name of the
-    # extension they belong to, to avoid clashing with functions from
-    # other extensions.
         return {'fork_get_parent_resource_details': get_parent_resource_details}

--- a/ckanext/fork/util.py
+++ b/ckanext/fork/util.py
@@ -1,4 +1,8 @@
+import logging
+import ckan.logic as logic
 from ckan.plugins import toolkit
+
+log = logging.getLogger(__name__)
 
 
 def get_forked_data(context, resource_id, activity_id=None):
@@ -49,3 +53,29 @@ def blob_storage_fork_resource(context, resource):
 
     resource['fork_activity'] = forked_data['activity_id']
     return resource
+
+
+def get_current_resource(context, resource):
+    current_resource = {}
+    if resource.get("id"):
+        try:
+            current_resource = toolkit.get_action('resource_show')(
+                context,
+                {"id": resource["id"]}
+            )
+        except logic.NotFound:
+            log.info(f"Resource {resource['id']} does not exist "
+                     "- must be creating a new resource with specific id.")
+    return current_resource
+
+
+def check_metadata_for_file_change(current, resource):
+    file_metadata_changed = False
+    if resource.get("fork_resource") or current.get("fork_resource"):
+        for key in ['lfs_prefix', 'size', 'sha256', 'url_type']:
+            new_value = resource.get(key, "")
+            if new_value:
+                original_value = current.get(key, "")
+                if original_value != new_value:
+                    file_metadata_changed = True
+    return file_metadata_changed


### PR DESCRIPTION
So I have refactored #16 slightly and also added a test suite for this bug:

- [x] creating new resource that is not a fork, i.e. ensure we don't break original behaviour: `TestResourceCreate.test_not_fork_resource_create()`
- [x] creating new resource that is fork: already done by pre-existing tests
- [x] changing fork resource to non-forked resource, i.e. ensure we don't break the ability to override a fork resource with non-fork data: `TestResourceUpdate.test_fork_resource_update_with_new_non_fork_resource_details()`
- [x] changing non-fork resource to fork: `TestResourceUpdate.test_non_fork_resource_update_with_new_fork_details()`
- [x] syncing fork resource after parent change: this is essentially tested by `TestResourceUpdate:test_fork_resource_update_with_activity_id()`
- [x] changing fields like description and permissions on forked resources: `TestResourceUpdate: test_fork_resource_update_with_new_metadata()`
- [x] uploading new file to a fork resource, overriding the forkiness but using the API instead of UI, i.e. the main bug we were trying to fix: ``TestResourceUpdate.test_non_fork_resource_update_with_new_fork_details_via_api_call()``

Also:
* renamed the test classes as the really calls to `resource_update` etc., which under the hood calls `package_update` etc. - this could be a preference thing but it just felt weird to have classes that said they were testing package actions but that never called package actions directly
* fixed a typo on (what is now) line 308
* added `fork` to four pre-existing test names for consistency with new tests