### PR TITLE
ADX-968 Bypass auth when checking if fork is synced

### DIFF
--- a/ckanext/fork/actions.py
+++ b/ckanext/fork/actions.py
@@ -174,4 +174,3 @@ def package_show(next_action, context, data_dict):
                 resource['fork_synced'] = util.is_synced_fork(context, resource)
 
     return dataset
-

--- a/ckanext/fork/tests/conftest.py
+++ b/ckanext/fork/tests/conftest.py
@@ -11,7 +11,8 @@ def forked_data():
         "lfs_prefix": "test/resource",
         "url_type": "upload"
     }
-    forked_dataset = factories.Dataset()
+    organization = factories.Organization()
+    forked_dataset = factories.Dataset(owner_org=organization['id'])
     forked_resource = factories.Resource(
         package_id=forked_dataset['id'],
         **giftless_metadata

--- a/ckanext/fork/tests/test_actions.py
+++ b/ckanext/fork/tests/test_actions.py
@@ -113,6 +113,21 @@ class TestPackageShow():
         response = call_action('resource_show', id=resource['id'])
         assert not response['fork_synced']
 
+    def test_no_access_to_forked_resource(self, forked_data):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            fork_resource=forked_data['resource']['id'],
+            fork_activity=forked_data['activity_id']
+        )
+        call_action('package_patch', id=forked_data['dataset']['id'], private=True)
+        user = factories.User()
+        response = toolkit.get_action('resource_show')(
+            {'user': user['name']},
+            {'id': resource['id']}
+        )
+        assert response['fork_synced']
+
 
 @pytest.mark.usefixtures('clean_db')
 class TestPackageCreate():

--- a/ckanext/fork/util.py
+++ b/ckanext/fork/util.py
@@ -33,7 +33,7 @@ def is_synced_fork(context, resource):
 
     forked_resource_id = resource.get('fork_resource')
     forked_resource_current_sha256 = toolkit.get_action("resource_show")(
-        {**context, 'check_synced': False},
+        {'ignore_auth': True, 'check_synced': False},
         {'id': forked_resource_id}
     ).get("sha256")
     return forked_resource_current_sha256 == resource.get("sha256")


### PR DESCRIPTION
Sierra Leone dataset was throwing a 404 not found error / authorization error when trying to simply view it.  See the Jira ticket for more details of the bug symptoms.

The bug was caused by ckanext-fork logic:

- A resource had been forked from an upstream resource that the user does not have access to.  
- When calling package_show action, ckanext-fork's chained action was checking if the fork was "synced" with upstream (aka the files match).  
- To do this it was calling resource_show for the upstream resource, to get it's sha256
- This was throwing an unauthorized error which was uncaught, therefore cascading to the top of the stack.  

The proposed solution is to simply bypass auth when checking if a fork is synced with upstream. So that wherever a forked resource exists, it is possible for everyone (not just those with access to the upstream resource) to know if the fork is synced with upstream or not. 

Chas and I have discussed and both feel this is ok.  But we would value @fulior's thoughts as well. Bypassing auth always feels a little tricksy. 

## Testing

A regression test is written that simply checks the user can view a resource forked from a private dataset. It breaks without the fix and passes with the fix. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [x] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [x] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
